### PR TITLE
Add rpm packages

### DIFF
--- a/sysreqs/bwidget.json
+++ b/sysreqs/bwidget.json
@@ -3,7 +3,8 @@
     "sysreqs": "/bwidget/i",
     "platforms": {
       "DEB": "bwidget",
-      "OSX/brew": "TODO"
+      "OSX/brew": "TODO",
+      "RPM": "bwidget"
     }
   }
 }

--- a/sysreqs/cairo.json
+++ b/sysreqs/cairo.json
@@ -6,7 +6,11 @@
         "runtime": "libcairo2",
         "buildtime": "libcairo2-dev"
       },
-      "OSX/brew": "cairo"
+      "OSX/brew": "cairo",
+      "RPM": {
+        "runtime": "cairo",
+        "buildtime": "cairo-devel"
+      }
     }
   }
 }

--- a/sysreqs/dcraw.json
+++ b/sysreqs/dcraw.json
@@ -3,6 +3,7 @@
     "sysreqs": "/dcraw/i",
     "platforms": {
       "DEB": "dcraw",
+      "RPM": "dcraw",
       "OSX/brew": "dcraw"
     }
   }

--- a/sysreqs/fftw3.json
+++ b/sysreqs/fftw3.json
@@ -5,7 +5,8 @@
       "DEB": {
         "runtime": "libfftw3-3",
         "buildtime": "libfftw3-dev"
-      }
+      },
+      "RPM": "fftw-devel"
     }
   }
 }

--- a/sysreqs/ggobi.json
+++ b/sysreqs/ggobi.json
@@ -3,7 +3,8 @@
     "sysreqs": "/ggobi/",
     "platforms": {
       "DEB": "ggobi",
-      "OSX/brew": "ggobi"
+      "OSX/brew": "ggobi",
+      "RPM": "ggobi"
     }
   }
 }

--- a/sysreqs/gnumake.json
+++ b/sysreqs/gnumake.json
@@ -3,7 +3,8 @@
     "sysreqs": "GNU make",
     "platforms": {
       "DEB": "make",
-      "OSX/brew": null
+      "OSX/brew": null,
+      "RPM": "make"
     }
   }
 }

--- a/sysreqs/imagemagick.json
+++ b/sysreqs/imagemagick.json
@@ -3,7 +3,8 @@
     "sysreqs": "/Image[ ]?Magick/i",
     "platforms": {
       "DEB": "imagemagick",
-      "OSX/brew": "imagemagick"
+      "OSX/brew": "imagemagick",
+      "RPM": "ImageMagick"
     }
   }
 }

--- a/sysreqs/java.json
+++ b/sysreqs/java.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "openjdk-7-jre-headless",
       "OSX/brew": null,
+      "RPM": "java-1.8.0-openjdk"
     }
   }
 }

--- a/sysreqs/libcurl.json
+++ b/sysreqs/libcurl.json
@@ -3,7 +3,8 @@
     "sysreqs": "libcurl",
     "platforms": {
       "DEB": "libcurl4-openssl-dev",
-      "OSX/brew": null
+      "OSX/brew": null,
+      "RPM": "libcurl-devel"
     }
   }
 }

--- a/sysreqs/libgsl.json
+++ b/sysreqs/libgsl.json
@@ -26,7 +26,11 @@
           "buildtime": "libgsl-dev"
         }
       ],
-      "OSX/brew": "gsl"
+      "OSX/brew": "gsl",
+      "RPM": {
+        "runtime": "gsl",
+        "buildtime": "gsl-devel"
+      }
     }
   }
 }

--- a/sysreqs/libxft.json
+++ b/sysreqs/libxft.json
@@ -5,6 +5,10 @@
       "DEB": {
         "runtime": "libxft2",
         "buildtime": "libxft-dev"
+      },
+      "RPM": {
+        "runtime": "libXft",
+        "buildtime": "libXft-devel"
       }
     }
   }

--- a/sysreqs/mysql.json
+++ b/sysreqs/mysql.json
@@ -3,7 +3,8 @@
     "sysreqs": "MySQL (>=5.6)",
     "platforms": {
       "DEB": ["mysql-server-5.6", "mysql-client-5.6"],
-      "OSX/brew": "mysql"
+      "OSX/brew": "mysql",
+      "RPM": ["mysql-server", "mysql"]
     }
   }
 }

--- a/sysreqs/openmpi.json
+++ b/sysreqs/openmpi.json
@@ -6,7 +6,11 @@
         "runtime": "libopenmpi1.6",
         "buildtime": "libopenmpi-dev"
       },
-      "OSX/brew": "openmpi"
+      "OSX/brew": "openmpi",
+      "RPM": {
+        "runtime": "openmpi",
+        "buildtime": "openmpi-devel"
+      }
     }
   }
 }

--- a/sysreqs/pdflatex.json
+++ b/sysreqs/pdflatex.json
@@ -4,6 +4,7 @@
     "platforms": {
       "DEB": "texlive-latex-base",
       "OSX/brew": null,
+      "RPM": "texlive-collection-basic"
     }
   }
 }

--- a/sysreqs/perl.json
+++ b/sysreqs/perl.json
@@ -3,7 +3,8 @@
     "sysreqs": "Perl (>=5)",
     "platforms": {
       "DEB": "perl",
-      "OSX/brew": null
+      "OSX/brew": null,
+      "RPM": "perl"
     }
   }
 }

--- a/sysreqs/python.json
+++ b/sysreqs/python.json
@@ -3,7 +3,8 @@
     "sysreqs": ["python (>= 2.7)", "python (>= 2.4)", "Python (>=2.76)"],
     "platforms": {
       "DEB": "python-minimal",
-      "OSX/brew": null
+      "OSX/brew": null,
+      "RPM": "python"
     }
   }
 }

--- a/sysreqs/tcltk.json
+++ b/sysreqs/tcltk.json
@@ -3,7 +3,8 @@
     "sysreqs": "Tcl/Tk (>= 8.5)",
     "platforms": {
       "DEB": ["tcl8.5", "tk8.6"],
-      "OSX/brew": "tcl-tk"
+      "OSX/brew": "tcl-tk",
+      "RPM": ["tcl", "tk"]
     }
   }
 }

--- a/sysreqs/tktable.json
+++ b/sysreqs/tktable.json
@@ -2,7 +2,8 @@
   "tktable": {
     "sysreqs": ["Tktable", "tktable"],
     "platforms": {
-      "DEB": "tk-table"
+      "DEB": "tk-table",
+      "RPM": "tktable"
     }
   }
 }


### PR DESCRIPTION
This PR adds the rpm packages that I could determine. I checked that the packages are valid for Fedora 23, but they should also work for 21 & 22. I have not checked CentOS and RHEL so far.