### PR TITLE
Correct os_type checking for windows

### DIFF
--- a/R/platform.R
+++ b/R/platform.R
@@ -132,7 +132,7 @@ detect_os <- function() {
 
   ostype <- os_type()
   sysname <- Sys.info()["sysname"]
-  if (ostype == "win") {
+  if (ostype == "windows") {
     "windows"
   } else if (sysname == "Darwin") {
     "osx"


### PR DESCRIPTION
fixes #6 

``` r
sysreqs:::os_type()
#> [1] "windows"
```

Created on 2018-02-17 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/r-hub/sysreqs/7)
<!-- Reviewable:end -->
