### PR TITLE
split up sysreq_commands function

### DIFF
--- a/R/commands.R
+++ b/R/commands.R
@@ -12,6 +12,11 @@ sysreq_commands <- function(desc, platform = current_platform(),
 
   pkgs <- sysreqs(desc, platform, soft = soft)
 
+  sysreq_commands_pkgs(pkgs, platform = platform)
+}
+
+
+sysreq_commands_pkgs <- function(pkgs, platform = current_platform()) {
   url <- make_url(
     sysreqs_platform_url,
     platform = platform


### PR DESCRIPTION
I split up this function into two separate functions so that I can use sysreqs in usecases for which I do not have a DESCRIPTION file, for example:

```r
Sys.setenv(RHUB_PLATFORM = "linux-x86_64-fedora-gcc")
deps <- sysreqs:::get_cran_deps("covr")
sysreqs <- sysreqs:::get_cran_sysreqs(deps)
syscommands <- sysreqs:::sysreq_commands_pkgs(sysreqs) # new function
```
